### PR TITLE
Feature/add mongo logrotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ This role uses the `package` Ansible module, so [its
 requirements](https://docs.ansible.com/ansible/latest/modules/package_module.html#requirements)
 apply.
 
+**IMPORTANT:** In order for this log rotation to work correctly, your
+mongod configuration file (typically found in `/etc/mongod.conf`)
+must contain the following settings:
+```
+systemLog:
+    logRotate: reopen
+processManagement:
+    pidFilePath: /var/run/mongodb/mongod.pid
+```
+
 ## Role Variables ##
 
 None.

--- a/files/mongo
+++ b/files/mongo
@@ -1,0 +1,17 @@
+# Default log rotation / compression keeps 1 year of logs.
+# Thanks to https://www.percona.com/blog/2018/09/27/automating-mongodb-log-rotation/
+/var/log/mongodb/*.log {
+    daily
+    rotate 365
+    dateext
+    missingok
+    compress
+    delaycompress
+    notifempty
+    extension gz
+    create 644 mongodb mongodb
+    sharedscripts
+    postrotate
+      /bin/kill -SIGUSR1 `cat /var/run/mongodb/mongod.pid 2>/dev/null` >/dev/null 2>&1
+    endscript
+}

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  author: David Redmin
+  description: Configure logrotate for MongoDB hosts
+  company: DHS NCATS
+  license: CC0
+  min_ansible_version: 2.0
+  platforms:
+    - name: Debian
+      versions:
+        - jessie
+        - stretch
+    - name: Amazon
+      versions:
+        - 2018.03
+  galaxy_tags:
+    - logrotate
+    - mongodb
+
+dependencies:
+  - src: https://github.com/dhs-ncats/ansible-role-logrotate
+    name: logrotate

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -1,0 +1,14 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates && xbps-remove -O; fi

--- a/molecule/default/INSTALL.rst
+++ b/molecule/default/INSTALL.rst
@@ -1,0 +1,16 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* General molecule dependencies (see https://molecule.readthedocs.io/en/latest/installation.html)
+* Docker Engine
+* docker-py
+* docker
+
+Install
+=======
+
+    $ sudo pip install docker-py

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,24 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+platforms:
+  - name: debian8
+    image: debian:jessie-slim
+  - name: debian9
+    image: debian:stretch-slim
+  - name: amazon2018.03
+    image: amazonlinux:2018.03
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+scenario:
+  name: default
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -1,0 +1,14 @@
+---
+# rsyslog is already installed on the AMIs we are using
+- name: Create
+  hosts: all
+  tasks:
+    - name: Install rsyslog
+      package:
+        name: rsyslog
+        state: present
+
+- name: Converge
+  hosts: all
+  roles:
+    - role: ansible-role-mongo-logrotate

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,0 +1,3 @@
+---
+- src: https://github.com/dhs-ncats/ansible-role-logrotate
+  name: logrotate

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -1,0 +1,26 @@
+import os
+import pytest
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+@pytest.mark.parametrize('pkg', [
+    'logrotate'
+])
+def test_packages(host, pkg):
+    package = host.package(pkg)
+
+    assert package.is_installed
+
+
+@pytest.mark.parametrize('file,content', [
+    ('/etc/logrotate.d/mongo', '^/var/log/mongodb')
+])
+def test_files(host, file, content):
+    f = host.file(file)
+
+    assert f.exists
+    assert f.contains(content)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+# tasks file for mongo_logrotate
+
+- name: Install mongo-specific logrotate configuration
+  copy:
+    src: mongo
+    dest: /etc/logrotate.d/mongo
+    mode: 0644


### PR DESCRIPTION
**Important note:** In order for this log rotation to work properly, your mongod configuration file (typically found in `/etc/mongod.conf`) must include the following:
```
systemLog:
    logRotate: reopen
processManagement:
    pidFilePath: /var/run/mongodb/mongod.pid
```